### PR TITLE
Updated documentation on admin page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,8 @@ class Admin extends NxusModule {
    *
    * ## Route Handlers
    *
-   * `admin.page('/route', (req, res) => {...})`
+   * `admin.page('/route', () => { // return a response to be rendered within admin template })`
+   * `admin.page({route: '/route', directHandler: true}, (req, res) => {...})`
    *
    * ## Options
    *


### PR DESCRIPTION
The example on how to register an admin page was slightly off, I updated the docs to include both a "render within the admin layout" option, and a "get a req and res object to do with what you will" option.