### PR TITLE
Revert action icon changes back to fa for web-actions templates

### DIFF
--- a/src/AdminController.js
+++ b/src/AdminController.js
@@ -69,10 +69,10 @@ class AdminController extends EditController {
     this.addNav('View', '', {icon: 'view'})
     this.addNav('Create', 'create', {icon: 'create'})
 
-    this.addAction('list', 'Add', "/create", {icon: 'add'})
-    this.addInstanceAction("Edit", "/edit/", {icon: 'edit'})
+    this.addAction('list', 'Add', "/create", {icon: 'fa fa-plus'})
+    this.addInstanceAction("Edit", "/edit/", {icon: 'fa fa-edit'})
     this.addInstanceAction("Delete", "/delete/", {
-      icon: 'delete',
+      icon: 'fa fa-remove',
       template: 'actions-button-post',
       templateMinimal: 'actions-icon-post'
     })
@@ -137,7 +137,7 @@ class AdminController extends EditController {
     }, ::this._download)
     nav.add(this.prefix+'-submenu', 'Download', exportRoute, {icon: 'download'})
     actions.add(this.templatePrefix+"-list", "Download", "/export", {
-      icon: 'download'
+      icon: 'fa fa-download'
     })
   }
 
@@ -163,7 +163,7 @@ class AdminController extends EditController {
 
     nav.add(this.prefix+'-submenu', 'Import', importRoute, {icon: 'upload'})
     actions.add(this.templatePrefix+"-list", "Import", "/import", {
-      icon: 'upload'
+      icon: 'fa fa-upload'
     })
 
   }


### PR DESCRIPTION
Since #28 only intended to make nav icons replaceable in templates, revert back to specifying the actual styles for icons to web-actions rather than needing to update web-actions templates to be aware of icon names and renaming.

I think this is the least change to get instance action buttons working again, but if we like the generic icon names -> template rewriting, the alternative is to make web-actions templates aware of these mappings.